### PR TITLE
Updated Swashbuckle package to 6.3.1

### DIFF
--- a/src/Plumsail.Swashbuckle.MicrosoftPowerAutomate/Plumsail.Swashbuckle.MicrosoftPowerAutomate.csproj
+++ b/src/Plumsail.Swashbuckle.MicrosoftPowerAutomate/Plumsail.Swashbuckle.MicrosoftPowerAutomate.csproj
@@ -48,6 +48,6 @@ v 1.1.0
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.1" />
 	</ItemGroup>
 </Project>

--- a/src/TestApi/TestApi.csproj
+++ b/src/TestApi/TestApi.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the Swashbuckle package to the latest version to verify an issue with this package. 

There appears to be a breaking change in 6.3.1 which doesn't allow this package with its current dependency on 6.2.3 to work as intended. Appears that upgrading the package here works as intended.